### PR TITLE
Fix for setting text attribute of tspan element

### DIFF
--- a/src/attr.js
+++ b/src/attr.js
@@ -316,6 +316,9 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                 node.appendChild(tuned.firstChild);
             }
         }
+        else if (this.type == "tspan") {
+            this.node.textContent = value;
+        }
         eve.stop();
     })(-1);
     function setFontSize(value) {


### PR DESCRIPTION
Setting text attribute of tspan element fails.
    var tspan = Snap('#text').select('tspan');
    var oldText = tspan.attr("text");
    tspan.attr({ "text": "new text" });
    var newText = tspan.attr("text");
    console.log(newText !== oldText);

Added case for tspan type, setting the node textContent property to the value.